### PR TITLE
update Hex2bin.hpp

### DIFF
--- a/src/Hex2Bin.hpp
+++ b/src/Hex2Bin.hpp
@@ -7,6 +7,7 @@
 #define __HEX2BIN_HPP__
 
 /* Includes -----------------------------------------------------------------*/
+#include <cstdint>
 #include <fstream>
 #include <vector>
 #include "config.h"


### PR DESCRIPTION
I encountered the following error while maintaining the [aur hex2bin-git](https://aur.archlinux.org/packages/hex2bin-git) package, and realized that it was a missing header file, which now compiles and passes.

<details>
  <summary>make log</summary>

```bash
etrieving sources...
==> WARNING: Skipping all source file integrity checks.
==> Extracting sources...
  -> Creating working copy of hex2bin-git git repo...
Cloning into 'hex2bin-git'...
done.
==> Starting pkgver()...
==> Starting build()...
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /usr/bin/python3.11 (found version "3.11.6") found components: Interpreter Development Development.Module Development.Embed 
Supported distrib.: cmake -DDISTRIBUTION=[debug|release]
Default start value: cmake -DDEFSTART=[int value] (see the '-s, --start' option of the binary)
Default limit value: cmake -DDEFLIMIT=[int value] (see the '-l, --limit' option of the binary)
-- Version: 1.9
-- Distrib.: =release
-- Default start value: 0
-- Default limit value: 0
-- Configuring done (0.7s)
-- Generating done (0.0s)
-- Build files have been written to: /build/hex2bin-git/src/hex2bin-git/build
ninja: Entering directory `build'
[1/4] Target update_sonar_version
[2/4] Building CXX object CMakeFiles/hex2bin.dir/src/main.cpp.o
[3/4] Building CXX object CMakeFiles/hex2bin.dir/src/Hex2Bin.cpp.o
FAILED: CMakeFiles/hex2bin.dir/src/Hex2Bin.cpp.o 
/usr/bin/c++ -DNDEBUG  -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2 -ffunction-sections -Wall -Werror -std=c++17 -std=gnu++17 -MD -MT CMakeFiles/hex2bin.dir/src/Hex2Bin.cpp.o -MF CMakeFiles/hex2bin.dir/src/Hex2Bin.cpp.o.d -o CMakeFiles/hex2bin.dir/src/Hex2Bin.cpp.o -c /build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp
In file included from /build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:7:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:25:8: error: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword [-Werror]
   25 |   enum class Hex2BinIsOpen: std::uint8_t
      |   ~~~~ ^~~~~
      |        -----
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:25:14: error: use of enum ‘Hex2BinIsOpen’ without previous declaration
   25 |   enum class Hex2BinIsOpen: std::uint8_t
      |              ^~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:25:27: error: expected unqualified-id before ‘:’ token
   25 |   enum class Hex2BinIsOpen: std::uint8_t
      |                           ^
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:33:8: error: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword [-Werror]
   33 |   enum class Hex2BinOpenResult: std::uint8_t
      |   ~~~~ ^~~~~
      |        -----
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:33:14: error: use of enum ‘Hex2BinOpenResult’ without previous declaration
   33 |   enum class Hex2BinOpenResult: std::uint8_t
      |              ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:33:31: error: expected unqualified-id before ‘:’ token
   33 |   enum class Hex2BinOpenResult: std::uint8_t
      |                               ^
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:50:50: error: ‘Hex2BinOpenResult’ does not name a type
   50 |       auto openInput(const std::string& path) -> Hex2BinOpenResult;
      |                                                  ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:57:51: error: ‘Hex2BinOpenResult’ does not name a type
   57 |       auto openOutput(const std::string& path) -> Hex2BinOpenResult;
      |                                                   ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:82:37: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   82 |       auto getStart() const -> std::uint32_t;
      |                                     ^~~~~~~~
      |                                     wint_t
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:102:37: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  102 |       auto getLimit() const -> std::uint32_t;
      |                                     ^~~~~~~~
      |                                     wint_t
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:108:35: error: ‘Hex2BinIsOpen’ does not name a type
  108 |       auto isFilesOpen() const -> Hex2BinIsOpen;
      |                                   ^~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:128:12: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  128 |       std::uint32_t m_start = DEFAULT_START;
      |            ^~~~~~~~
      |            wint_t
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:129:12: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  129 |       std::uint32_t m_limit = DEFAULT_LIMIT;
      |            ^~~~~~~~
      |            wint_t
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:174:101: error: ‘Hex2BinOpenResult’ does not name a type
  174 |       auto openFile(Stream& stream, const std::string& path, std::ios_base::openmode mode) const -> Hex2BinOpenResult;
      |                                                                                                     ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:183:38: error: ‘std::uint32_t’ has not been declared
  183 |       static auto setValueFromstring(std::uint32_t& output, const std::string& value, std::string& what) -> bool;
      |                                      ^~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:49:53: error: ‘Hex2BinOpenResult’ does not name a type
   49 | auto Hex2Bin::openInput(const std::string& path) -> Hex2BinOpenResult
      |                                                     ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:60:54: error: ‘Hex2BinOpenResult’ does not name a type
   60 | auto Hex2Bin::openOutput(const std::string& path) -> Hex2BinOpenResult
      |                                                      ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: In member function ‘bool h2b::Hex2Bin::setStart(const std::string&, std::string&)’:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:73:29: error: ‘m_start’ was not declared in this scope
   73 |   return setValueFromstring(m_start, value, what);
      |                             ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: In member function ‘bool h2b::Hex2Bin::isValidStart() const’:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:82:16: error: ‘m_start’ was not declared in this scope
   82 |   return 0U != m_start;
      |                ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: At global scope:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:89:6: error: no declaration matches ‘uint32_t h2b::Hex2Bin::getStart() const’
   89 | auto Hex2Bin::getStart() const -> std::uint32_t
      |      ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:89:6: note: no functions named ‘uint32_t h2b::Hex2Bin::getStart() const’
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:40:9: note: ‘class h2b::Hex2Bin’ defined here
   40 |   class Hex2Bin
      |         ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: In member function ‘bool h2b::Hex2Bin::setLimit(const std::string&, std::string&)’:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:102:29: error: ‘m_limit’ was not declared in this scope
  102 |   return setValueFromstring(m_limit, value, what);
      |                             ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: In member function ‘bool h2b::Hex2Bin::isValidLimit() const’:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:111:16: error: ‘m_limit’ was not declared in this scope
  111 |   return 0U != m_limit;
      |                ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: At global scope:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:118:6: error: no declaration matches ‘uint32_t h2b::Hex2Bin::getLimit() const’
  118 | auto Hex2Bin::getLimit() const -> std::uint32_t
      |      ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:118:6: note: no functions named ‘uint32_t h2b::Hex2Bin::getLimit() const’
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:40:9: note: ‘class h2b::Hex2Bin’ defined here
   40 |   class Hex2Bin
      |         ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:127:38: error: ‘Hex2BinIsOpen’ does not name a type
  127 | auto Hex2Bin::isFilesOpen() const -> Hex2BinIsOpen
      |                                      ^~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: In member function ‘std::string h2b::Hex2Bin::getFragment(std::string_view) const’:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:271:12: error: ‘m_start’ was not declared in this scope
  271 |   if(len < m_start)
      |            ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:275:21: error: ‘m_limit’ was not declared in this scope
  275 |   const auto lim = (m_limit == 0 || m_limit > len) ? len : m_limit;
      |                     ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:276:43: error: ‘m_start’ was not declared in this scope
  276 |   return std::string(line.substr(std::min(m_start, static_cast<std::uint32_t>(len)), lim));
      |                                           ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp: At global scope:
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:340:104: error: ‘Hex2BinOpenResult’ does not name a type
  340 | auto Hex2Bin::openFile(Stream& stream, const std::string& path, std::ios_base::openmode mode) const -> Hex2BinOpenResult
      |                                                                                                        ^~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.cpp:368:6: error: no declaration matches ‘bool h2b::Hex2Bin::setValueFromstring(uint32_t&, const std::string&, std::string&)’
  368 | auto Hex2Bin::setValueFromstring(std::uint32_t& output, const std::string& value, std::string& what) -> bool
      |      ^~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:183:19: note: candidate is: ‘static bool h2b::Hex2Bin::setValueFromstring(int&, const std::string&, std::string&)’
  183 |       static auto setValueFromstring(std::uint32_t& output, const std::string& value, std::string& what) -> bool;
      |                   ^~~~~~~~~~~~~~~~~~
/build/hex2bin-git/src/hex2bin-git/src/Hex2Bin.hpp:40:9: note: ‘class h2b::Hex2Bin’ defined here
   40 |   class Hex2Bin
      |         ^~~~~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
==> ERROR: A failure occurred in build().
    Aborting...
==> ERROR: Build failed, check /var/lib/archbuild/extra-x86_64/taotieren/build


```

</details>